### PR TITLE
Enforce sphinx linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ lint.select = ["E4", "E7", "E9", "F", "ANN", "E501", "D101", "D102", "D103", "D1
 [tool.pydoclint]
 style = "sphinx"
 exclude = "venv|.tox|.git"
+skip-checking-short-docstrings = false
 
 # these are already enforced through ruff (pydocstyle)
 arg-type-hints-in-docstring = false


### PR DESCRIPTION
Default behaviour does not attempt to enforce metadata if only a description is passed.